### PR TITLE
Fix handling of missing hop location data

### DIFF
--- a/traceRouteV2.py
+++ b/traceRouteV2.py
@@ -73,11 +73,17 @@ def traceroute_route():
                               tooltip=f'<b>Hop :{i + 1} IP :{ip_address}  Latitude : {latitude} Longitude: {longitude}</b>', # adds a tooltip with information about the hop
                               popup=f'<b>Hop {i + 1}: {ip_address}, {address}, Latitude: {latitude}, Longitude: {longitude}</b>', # adds a popup with detailed information about the hop
                               icon=folium.Icon(color='green', icon_color='white', icon='ok-circle')).add_to(map_location) # sets the marker's color and icon
-                if i < len(ans) - 1: # checks if this is not the last hop in the traceroute
-                    next_hop = ans[i + 1][1].src # gets the source IP address of the next hop
-                    folium.PolyLine(locations=[(latitude, longitude), get_location_data(next_hop)[1:]], # adds a line between the current hop and the next hop
-                                    color=colors[color_index % len(colors)]).add_to(map_location) # sets the line's color
-                    color_index += 1
+                if i < len(ans) - 1:  # checks if this is not the last hop in the traceroute
+                    next_hop = ans[i + 1][1].src  # gets the source IP address of the next hop
+                    next_location = get_location_data(next_hop)
+                    if next_location:
+                        folium.PolyLine(
+                            locations=[(latitude, longitude), next_location[1:]],
+                            color=colors[color_index % len(colors)]
+                        ).add_to(map_location)
+                        color_index += 1
+                    else:
+                        logger.info(f'Hop {i + 2}: {next_hop} - could not retrieve location data')
                 # If location data is not available, log it and continue to the next hop
 
             else:


### PR DESCRIPTION
## Summary
- handle cases where hop coordinates are not returned when drawing PolyLines

## Testing
- `python -m py_compile traceRouteV2.py`

------
https://chatgpt.com/codex/tasks/task_e_6846fd184f3c8327adfc26f06b1a0f40