### PR TITLE
Use active index template in legacy Flask app

### DIFF
--- a/templates/index1.html
+++ b/templates/index1.html
@@ -1,2 +1,0 @@
-<!doctype html>
-<html><body><p>Deprecated template. Use traceroute_visualizer/templates/index.html.</p></body></html>

--- a/traceRouteV2.py
+++ b/traceRouteV2.py
@@ -8,7 +8,11 @@ import folium
 from flask import Flask, render_template, request
 
 # create a Flask application instance
-app = Flask(__name__)
+app = Flask(
+    __name__,
+    template_folder="traceroute_visualizer/templates",
+    static_folder="traceroute_visualizer/static",
+)
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
@@ -64,7 +68,7 @@ def get_location_data(ip_address):
 
 @app.route("/")
 def index():
-    return render_template("index1.html")  # render an HTML template for the index page
+    return render_template("index.html")  # render an HTML template for the index page
 
 
 @app.route("/traceroute", methods=["POST"])
@@ -165,8 +169,8 @@ def traceroute_route():
     # Save the map as an HTML file and open it in a new browser tab
     map_location.save("hops.html")
     webbrowser.open("hops.html")
-    # Render the index1.html template
-    return render_template("index1.html")
+    # Render the index.html template
+    return render_template("index.html")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- The legacy `traceRouteV2.py` Flask entrypoint referenced a deprecated placeholder template and the project-maintained templates/static assets lived under `traceroute_visualizer/`, so routing should use the active assets. 

### Description
- Configure the Flask app in `traceRouteV2.py` to load `template_folder="traceroute_visualizer/templates"` and `static_folder="traceroute_visualizer/static"` for consistent asset resolution. 
- Replace rendering of the deprecated `index1.html` with the active `index.html` in both the `/` and `/traceroute` route handlers in `traceRouteV2.py`. 
- Remove the deprecated placeholder file `templates/index1.html` from the repository. 

### Testing
- Ran the test suite with `pytest -q` and all tests passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699d52d56fa88331885b0d07c885c55e)